### PR TITLE
Draft: Add override ACL binding processing

### DIFF
--- a/src/test/java/io/bf2/kafka/authorizer/CustomAclAuthorizerIT.java
+++ b/src/test/java/io/bf2/kafka/authorizer/CustomAclAuthorizerIT.java
@@ -1,5 +1,6 @@
 package io.bf2.kafka.authorizer;
 
+import io.bf2.kafka.authorizer.CustomAclBinding.Category;
 import org.apache.kafka.common.acl.AccessControlEntry;
 import org.apache.kafka.common.acl.AccessControlEntryFilter;
 import org.apache.kafka.common.acl.AclBinding;
@@ -369,7 +370,7 @@ class CustomAclAuthorizerIT {
                                                      new AccessControlEntry("User:*", "*", AclOperation.ALL, AclPermissionType.UNKNOWN),
                                                      "*",
                                                      Set.of(),
-                                                     true));
+                                                     Category.DEFAULT_BINDING));
 
             auth.configureDefaults(defaultBindings);
             assertEquals(2, StreamSupport.stream(auth.acls(AclBindingFilter.ANY).spliterator(), false).count());

--- a/src/test/java/io/bf2/kafka/authorizer/CustomAclAuthorizerTest.java
+++ b/src/test/java/io/bf2/kafka/authorizer/CustomAclAuthorizerTest.java
@@ -82,7 +82,7 @@ class CustomAclAuthorizerTest {
         try (CustomAclAuthorizer auth = new CustomAclAuthorizer(this.delegate)) {
             auth.configure(config);
 
-            Set<CustomAclBinding> uniqueBindings = auth.aclMap.values()
+            Set<CustomAclBinding> uniqueBindings = auth.predelegationAclMap.values()
                 .stream()
                 .flatMap(List::stream)
                 .collect(Collectors.toCollection(HashSet::new));
@@ -114,7 +114,7 @@ class CustomAclAuthorizerTest {
         try (CustomAclAuthorizer auth = new CustomAclAuthorizer(this.delegate)) {
             auth.configure(config);
 
-            List<CustomAclBinding> matchedBindings = auth.aclMap.get(expResourceType)
+            List<CustomAclBinding> matchedBindings = auth.predelegationAclMap.get(expResourceType)
                     .stream()
                     .filter(binding -> binding.pattern().resourceType() == expResourceType)
                     .filter(binding -> binding.pattern().name().equals(expResourceName))


### PR DESCRIPTION
@k-wall - please take a look at this possible approach to provide an "override" ACL that allows for post-delegation denial of operations allowed by the Kafka AclAuthorizer. Not yet tested, just brainstorming on how to do it so far.

Signed-off-by: Michael Edgar <medgar@redhat.com>