### PR TITLE
Log AuthorizationResults from delegate

### DIFF
--- a/src/main/java/io/bf2/kafka/authorizer/CustomAclAuthorizer.java
+++ b/src/main/java/io/bf2/kafka/authorizer/CustomAclAuthorizer.java
@@ -287,16 +287,16 @@ public class CustomAclAuthorizer implements Authorizer {
     private AuthorizationResult authorizeAction(AuthorizableRequestContext requestContext, Action action) {
         // is super user allow any operation
         if (delegate.isSuperUser(requestContext.principal())) {
-            if (log.isDebugEnabled()) {
-                log.debug("super.user {}", buildLogMessage(requestContext, action, true));
+            if (log.isInfoEnabled()) {
+                log.info("super.user {}", buildLogMessage(requestContext, action, true));
             }
             return AuthorizationResult.ALLOWED;
         }
 
         // if request made on any allowed listeners allow always
         if (isAllowedListener(requestContext.listenerName())) {
-            if (log.isDebugEnabled()) {
-                log.debug("allowed listener {}", buildLogMessage(requestContext, action, true));
+            if (log.isInfoEnabled()) {
+                log.info("allowed listener {}", buildLogMessage(requestContext, action, true));
             }
             return AuthorizationResult.ALLOWED;
         }
@@ -400,11 +400,8 @@ public class CustomAclAuthorizer implements Authorizer {
     }
 
     public void logAuditMessage(AuthorizableRequestContext requestContext, Action action, boolean authorized) {
-        if (authorized && action.logIfAllowed()) {
-            if (log.isDebugEnabled()) {
-                log.debug(buildLogMessage(requestContext, action, authorized));
-            }
-        } else if (!authorized && action.logIfDenied()) {
+        if ((authorized && action.logIfAllowed()) ||
+                (!authorized && action.logIfDenied())) {
             if (log.isInfoEnabled()) {
                 log.info(buildLogMessage(requestContext, action, authorized));
             }


### PR DESCRIPTION
Before this changeBefore this change, the `logAuditMessage` method
(almost?) never gets called for ALLOWED authorization results, because
these results appear to usually (always?) come from the delegate,
which was just being returned here at the end of the authorization
logic.

There's also an optional second commit added here to upgrade the
logging of ALLOWED authorization results to INFO level, so that they
can be logged without causing the logs to be flooded by other DEBUG
level logs that occur in this package for all replication and canary
events (multiple additional logs per second per broker).

If that second commit is not desired at this point, I can remove it.