### PR TITLE
windowing the logging of produce/fetch requests

### DIFF
--- a/src/test/java/io/bf2/kafka/authorizer/CustomAclAuthorizerTest.java
+++ b/src/test/java/io/bf2/kafka/authorizer/CustomAclAuthorizerTest.java
@@ -199,6 +199,14 @@ class CustomAclAuthorizerTest {
 
             assertEquals(1, results.size());
             assertEquals(expectedResult, results.get(0));
+
+            // authorize again and check the cache size
+            results = auth.authorize(rc, Arrays.asList(action));
+            if (expectedResult == AuthorizationResult.ALLOWED && (requestType == ApiKeys.FETCH.id || requestType == ApiKeys.PRODUCE.id)) {
+                assertEquals(1, auth.lastAuthorizedLogCache.size());
+            } else {
+                assertEquals(0, auth.lastAuthorizedLogCache.size());
+            }
         }
     }
 


### PR DESCRIPTION
Just a musing on a narrow change to window produce/fetch.  If needed the configuration of the cache window can be externalized.