### PR TITLE
use provided scope for dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,6 @@
         <junit.version>5.7.1</junit.version>
         <mockito.version>1.10.19</mockito.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <jackson-core.version>2.10.5</jackson-core.version>
-        <jackson-databind.version>2.10.5.1</jackson-databind.version>
         <guava.version>30.0-jre</guava.version>
         <zookeeper.version>3.6.3</zookeeper.version>
         <kafka-junit.version>4.2.0</kafka-junit.version>
@@ -82,22 +80,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>${jackson-core.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -170,6 +155,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
+                    <argLine>-Xmx1024m</argLine>
+                    <forkedProcessTimeoutInSeconds>60</forkedProcessTimeoutInSeconds>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                 </configuration>
                 <executions>


### PR DESCRIPTION
When kafka pulls in the dependency, we want to ensure its versions of dependencies reign over ours.