### PR TITLE
Default to no private topic prefix

### DIFF
--- a/src/main/java/io/bf2/kafka/common/PartitionCounter.java
+++ b/src/main/java/io/bf2/kafka/common/PartitionCounter.java
@@ -66,7 +66,7 @@ public class PartitionCounter implements AutoCloseable {
     /**
      * Custom broker property key, used to specify the topic prefix to match for private/internal topics
      * in the {@link #countExistingPartitions()} method, where partitions from those topics will not be
-     * counted. If this property is not specified, a default of {@link #DEFAULT_PRIVATE_TOPIC_PREFIX}
+     * counted. If this property is not specified, a default of {@link #DEFAULT_NO_PRIVATE_TOPIC_PREFIX}
      * will be used in this class.
      */
     public static final String PRIVATE_TOPIC_PREFIX = CREATE_TOPIC_POLICY_PREFIX + "partition-counter.private-topic-prefix";
@@ -88,7 +88,7 @@ public class PartitionCounter implements AutoCloseable {
     static final int DEFAULT_MAX_PARTITIONS = -1;
     static final int DEFAULT_TIMEOUT_SECONDS = 10;
     static final int DEFAULT_SCHEDULE_INTERVAL_SECONDS = 15;
-    static final String DEFAULT_PRIVATE_TOPIC_PREFIX = "__redhat_";
+    static final String DEFAULT_NO_PRIVATE_TOPIC_PREFIX = "";
     static final boolean DEFAULT_LIMIT_ENFORCED = false;
 
     private static final String GROUP_METADATA_TOPIC_NAME = "__consumer_offsets";
@@ -97,7 +97,7 @@ public class PartitionCounter implements AutoCloseable {
     private static final ConfigDef configDef = new ConfigDef()
             .define(LIMIT_ENFORCED, ConfigDef.Type.BOOLEAN, DEFAULT_LIMIT_ENFORCED, ConfigDef.Importance.MEDIUM, "Feature flag to allow enabling of partition limit enforcement")
             .define(MAX_PARTITIONS, ConfigDef.Type.INT, DEFAULT_MAX_PARTITIONS, ConfigDef.Importance.MEDIUM, "Max partitions")
-            .define(PRIVATE_TOPIC_PREFIX, ConfigDef.Type.STRING, DEFAULT_PRIVATE_TOPIC_PREFIX, ConfigDef.Importance.MEDIUM, "Internal Partition Prefix")
+            .define(PRIVATE_TOPIC_PREFIX, ConfigDef.Type.STRING, DEFAULT_NO_PRIVATE_TOPIC_PREFIX, ConfigDef.Importance.MEDIUM, "Internal Partition Prefix")
             .define(TIMEOUT_SECONDS, ConfigDef.Type.INT, DEFAULT_TIMEOUT_SECONDS,ConfigDef.Importance.MEDIUM, "Timeout duration for listing and describing topics")
             .define(SCHEDULE_INTERVAL_SECONDS, ConfigDef.Type.INT, DEFAULT_SCHEDULE_INTERVAL_SECONDS,ConfigDef.Importance.MEDIUM, "Schedule interval for scheduled counter");
 

--- a/src/test/java/io/bf2/kafka/common/PartitionCounterIT.java
+++ b/src/test/java/io/bf2/kafka/common/PartitionCounterIT.java
@@ -30,11 +30,13 @@ class PartitionCounterIT {
         void testOnlyCountPublicTopicPartitions(KafkaHelper kafkaHelper)
                 throws InterruptedException, ExecutionException, TimeoutException {
             try (Admin admin = Admin.create(kafkaHelper.consumerConfig())) {
-                final int PUBLIC_PARTITION_COUNT = 20;
+                final int PUBLIC_PARTITION_COUNT = 30;
+                final String customPrivateTopicPrefix = "__kas_";
                 List<NewTopic> newTopics = List.of(
-                        new NewTopic("topic1", PUBLIC_PARTITION_COUNT / 2, (short) 1),
-                        new NewTopic("topic2", PUBLIC_PARTITION_COUNT / 2, (short) 1),
-                        new NewTopic(PartitionCounter.DEFAULT_PRIVATE_TOPIC_PREFIX + "topic", 11, (short) 1),
+                        new NewTopic("topic1", PUBLIC_PARTITION_COUNT / 3, (short) 1),
+                        new NewTopic("topic2", PUBLIC_PARTITION_COUNT / 3, (short) 1),
+                        new NewTopic(PartitionCounter.DEFAULT_NO_PRIVATE_TOPIC_PREFIX + "topic", PUBLIC_PARTITION_COUNT / 3, (short) 1),
+                        new NewTopic(customPrivateTopicPrefix + "topic", 11, (short) 1),
                         new NewTopic("__consumer_offsets", 12, (short) 1),
                         new NewTopic("__transaction_state", 13, (short) 1));
                 CreateTopicsResult result = admin.createTopics(newTopics);
@@ -43,6 +45,7 @@ class PartitionCounterIT {
                 Map<String, Object> config = Stream.concat(
                         kafkaHelper.consumerConfig().entrySet().stream(),
                         Map.of(
+                                PartitionCounter.PRIVATE_TOPIC_PREFIX, "__kas_",
                                 LocalAdminClient.LISTENER_NAME, "test",
                                 LocalAdminClient.LISTENER_PORT, kafkaHelper.kafkaPort(),
                                 LocalAdminClient.LISTENER_PROTOCOL, "PLAINTEXT").entrySet().stream())

--- a/src/test/java/io/bf2/kafka/topic/ManagedKafkaCreateTopicPolicyTest.java
+++ b/src/test/java/io/bf2/kafka/topic/ManagedKafkaCreateTopicPolicyTest.java
@@ -29,6 +29,7 @@ class ManagedKafkaCreateTopicPolicyTest {
             ManagedKafkaCreateTopicPolicy.MIN_INSYNC_REPLICAS, 2,
             PartitionCounter.MAX_PARTITIONS, 1000,
             PartitionCounter.LIMIT_ENFORCED, true,
+            PartitionCounter.PRIVATE_TOPIC_PREFIX, "__kas_",
             LocalAdminClient.LISTENER_NAME, "controlplane",
             LocalAdminClient.LISTENER_PORT, "9090",
             LocalAdminClient.LISTENER_PROTOCOL, "PLAINTEXT");
@@ -169,9 +170,9 @@ class ManagedKafkaCreateTopicPolicyTest {
         "topic1, 10, 3, 1, DENIED",
         "topic1, 9999, 3, 2, DENIED",
 
-        "__redhat_topic1, 10, 1, 2, ALLOWED",
-        "__redhat_topic1, 10, 3, 1, ALLOWED",
-        "__redhat_topic1, 9999, 3, 2, ALLOWED",
+        "__kas_topic1, 10, 1, 2, ALLOWED",
+        "__kas_topic1, 10, 3, 1, ALLOWED",
+        "__kas_topic1, 9999, 3, 2, ALLOWED",
     })
     void testTopicValidationBypass(String topicName, int partitions, short replicationFactor, int isr,
             String expectedResult) throws Exception {


### PR DESCRIPTION
This property can be optionally set to a prefix value to make use of private topics.