### PR TITLE
fix flakey tests - turn off parallel tests for surefire & fix partitioncounter leak in test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,8 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <useUnlimitedThreads>false</useUnlimitedThreads>
+                    <forkCount>1</forkCount>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/test/java/io/bf2/kafka/topic/ManagedKafkaCreateTopicPolicyTest.java
+++ b/src/test/java/io/bf2/kafka/topic/ManagedKafkaCreateTopicPolicyTest.java
@@ -58,6 +58,7 @@ class ManagedKafkaCreateTopicPolicyTest {
     @AfterEach
     void tearDown() {
         policy.close();
+        disabledPolicy.close();
     }
 
     @Test

--- a/src/test/resources/io/bf2/kafka/authorizer/CustomAclAuthorizerTest.properties
+++ b/src/test/resources/io/bf2/kafka/authorizer/CustomAclAuthorizerTest.properties
@@ -40,3 +40,6 @@ kas.authorizer.acl.logging.006=topic=important_topic;level=WARN
 kas.policy.shared-admin.adminclient-listener.name=controlplane
 kas.policy.shared-admin.adminclient-listener.port=9090
 kas.policy.shared-admin.adminclient-listener.protocol=PLAINTEXT
+
+# Override suppression window (tests control use explicit invalidation)
+kas.authorizer.acl.logging.suppressionWindow.duration=PT5M


### PR DESCRIPTION
AuditLoggingControllerTest can't run in parallel with other test classes because of the way it configures the logging stack (which is effectively a singleton).   This change turns off parallel tests.

Also fixed a partitioncounter leak  in the new tests associated with topic policy tests.