### PR TITLE
Mockito upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <slf4j.version>1.7.30</slf4j.version>
         <guava.version>30.0-jre</guava.version>
         <zookeeper.version>3.6.3</zookeeper.version>
-        <kafka-junit.version>4.2.2</kafka-junit.version>
+        <kafka-junit.version>4.2.1</kafka-junit.version>
         <curator-test.version>5.2.0</curator-test.version>
         <awaitility.version>4.2.0</awaitility.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -38,12 +38,12 @@
 
         <kafka.version>3.0.1</kafka.version>
         <basescala.version>2.13</basescala.version>
-        <junit.version>5.7.1</junit.version>
-        <mockito.version>1.10.19</mockito.version>
+        <junit.version>5.8.2</junit.version>
+        <mockito.version>4.6.1</mockito.version>
         <slf4j.version>1.7.30</slf4j.version>
         <guava.version>30.0-jre</guava.version>
         <zookeeper.version>3.6.3</zookeeper.version>
-        <kafka-junit.version>4.2.0</kafka-junit.version>
+        <kafka-junit.version>4.2.2</kafka-junit.version>
         <curator-test.version>5.2.0</curator-test.version>
         <awaitility.version>4.2.0</awaitility.version>
     </properties>
@@ -123,7 +123,13 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>

--- a/src/test/java/io/bf2/kafka/authorizer/CustomAclAuthorizerTest.java
+++ b/src/test/java/io/bf2/kafka/authorizer/CustomAclAuthorizerTest.java
@@ -61,9 +61,9 @@ class CustomAclAuthorizerTest {
     void setup() {
         this.delegate = Mockito.mock(kafka.security.authorizer.AclAuthorizer.class);
 
-        Mockito.when(this.delegate.authorize(Mockito.any(AuthorizableRequestContext.class), Mockito.anyListOf(Action.class)))
+        Mockito.when(this.delegate.authorize(Mockito.any(AuthorizableRequestContext.class), Mockito.anyList()))
             .thenAnswer(invocation -> {
-                int count = invocation.getArgumentAt(1, List.class).size();
+                int count = invocation.getArgument(1, List.class).size();
                 List<AuthorizationResult> results = new ArrayList<>(count);
                 for (int i = 0; i < count; i++) {
                     results.add(AuthorizationResult.DENIED);


### PR DESCRIPTION
Bumping mockito from 1.0.19 as it suffers from 
```
 Error:  WARNING: An illegal reflective access operation has occurred
Error:  WARNING: Illegal reflective access by org.mockito.cglib.core.ReflectUtils$2 (file:/home/runner/.m2/repository/org/mockito/mockito-all/1.10.19/mockito-all-1.10.19.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain)
Error:  WARNING: Please consider reporting this to the maintainers of org.mockito.cglib.core.ReflectUtils$2
Error:  WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
Error:  WARNING: All illegal access operations will be denied in a future release
```

When running with JDK 11 and fails on JDK 17 (I haven't checked where in between it changes from warning to error).

Bumping the other test scope dependencies while I'm there.