### PR TITLE
[WIP] MGDSTRM-9202: make `segment.jitter.ms` as immutable config

### DIFF
--- a/src/main/java/io/bf2/kafka/common/Config.java
+++ b/src/main/java/io/bf2/kafka/common/Config.java
@@ -23,7 +23,6 @@ import static org.apache.kafka.common.config.TopicConfig.RETENTION_BYTES_CONFIG;
 import static org.apache.kafka.common.config.TopicConfig.RETENTION_MS_CONFIG;
 import static org.apache.kafka.common.config.TopicConfig.SEGMENT_BYTES_CONFIG;
 import static org.apache.kafka.common.config.TopicConfig.SEGMENT_INDEX_BYTES_CONFIG;
-import static org.apache.kafka.common.config.TopicConfig.SEGMENT_JITTER_MS_CONFIG;
 import static org.apache.kafka.common.config.TopicConfig.SEGMENT_MS_CONFIG;
 import static org.apache.kafka.common.config.TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG;
 
@@ -79,7 +78,6 @@ public class Config {
             INDEX_INTERVAL_BYTES_CONFIG + ":4096",
             MIN_CLEANABLE_DIRTY_RATIO_CONFIG + ":0.5",
             PREALLOCATE_CONFIG + ":false",
-            SEGMENT_JITTER_MS_CONFIG + ":0",
             UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG + ":false",
             SEGMENT_INDEX_BYTES_CONFIG + ":10485760"
     );
@@ -103,7 +101,6 @@ public class Config {
             RETENTION_MS_CONFIG,
             SEGMENT_BYTES_CONFIG,
             SEGMENT_INDEX_BYTES_CONFIG,
-            SEGMENT_JITTER_MS_CONFIG,
             SEGMENT_MS_CONFIG,
             UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG,
             MESSAGE_DOWNCONVERSION_ENABLE_CONFIG


### PR DESCRIPTION
In this PR, I make `segment.jitter.ms` as immutable config.


For `min.insync.replicas`, The epic brief said:
```
min.insync.replicas=2 should be allowed in standard and 1 for developer.
```
Currently, I make it as `immutable` config, which is an easier implementation. But that would throw exception when, for example, user tried to set `min.insync.replicas=2` in standard cluster. 

To allow it set to 2 when in standard, and 1 in developer, we can do:
1. dynamically set this `kas.policy.topic-config.enforced` config based on the cluster mode (standard/developer) in fleetshard. We can't just blindly set a default value like other settings.
2. or, add a new config, ex: `kas.policy.topic-config.min-insync-replica.enforced=true`, so that it'll override any policy configs, and only allow broker `min.insync.replicas` value. For example, when `kas.policy.topic-config.min-insync-replica.enforced=true`, and `kas.policy.topic-config.enforced="min.insync.replicas:1"` are set, we'll ignore the `min.insync.replicas:1` setting, and only allow broker configured `min.insync.replicas` value. Although this way works, I think it makes the configuration more complex.
3. or, we keep our current solution, to make `min.insync.replicas` as immutable config. Basically, it still follows the epic brief, to only allow min.insync.replicas=2 in standard and 1 for developer. So, it's fine to keep it as is
4. or any other suggestion?

I'd like to hear your thoughts. Thanks.