### PR TITLE
Update to Kafka 3.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <basescala.version>2.13</basescala.version>
         <junit.version>5.8.2</junit.version>
         <mockito.version>4.6.1</mockito.version>
-        <slf4j.version>1.7.30</slf4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
         <guava.version>30.0-jre</guava.version>
         <zookeeper.version>3.6.3</zookeeper.version>
         <kafka-junit.version>4.2.1</kafka-junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <basepom.check.fail-dependency>false</basepom.check.fail-dependency>
         <basepom.check.skip-dependency-scope>true</basepom.check.skip-dependency-scope>
 
-        <kafka.version>3.0.1</kafka.version>
+        <kafka.version>3.2.3</kafka.version>
         <basescala.version>2.13</basescala.version>
         <junit.version>5.8.2</junit.version>
         <mockito.version>4.6.1</mockito.version>

--- a/src/test/java/io/bf2/kafka/authorizer/AuditLoggingControllerTest.java
+++ b/src/test/java/io/bf2/kafka/authorizer/AuditLoggingControllerTest.java
@@ -69,8 +69,8 @@ class AuditLoggingControllerTest {
             "Test log level for specified binding is as expected, DEBUG, DESCRIBE, METADATA, TOPIC, myopictopic, User:test, true",
             "Test can specify fetch API, TRACE, CLUSTER_ACTION, FETCH, CLUSTER, kafka-cluster, User:test, true",
             "Test can turn off some operations per topic, TRACE, DESCRIBE, METADATA, TOPIC, __strimzi_canary, User:canary-something, true",
-            "Test prioritization considering level, DEBUG, CLUSTER_ACTION, ALTER_ISR, CLUSTER, kafka-cluster, User:test, true",
-            "Test override can't go below INFO, INFO, CLUSTER_ACTION, ALTER_ISR, CLUSTER, kafka-cluster, User:test, false",
+            "Test prioritization considering level, DEBUG, CLUSTER_ACTION, ALTER_PARTITION, CLUSTER, kafka-cluster, User:test, true",
+            "Test override can't go below INFO, INFO, CLUSTER_ACTION, ALTER_PARTITION, CLUSTER, kafka-cluster, User:test, false",
             "Test override can go above INFO, WARN, READ, METADATA, TOPIC, important_topic, User:bob, false",
     })
     void testGetLogLevel(String title,

--- a/src/test/resources/io/bf2/kafka/authorizer/CustomAclAuthorizerTest.properties
+++ b/src/test/resources/io/bf2/kafka/authorizer/CustomAclAuthorizerTest.properties
@@ -31,8 +31,8 @@ kas.authorizer.acl.logging.002=topic=*;operations=describe;level=DEBUG
 kas.authorizer.acl.logging.003=priority=1;topic=__strimzi_canary;operations=describe,read,write;level=TRACE
 
 # DEBUG has a higher priority than TRACE
-kas.authorizer.acl.logging.004=cluster=*;apis=ALTER_ISR;level=TRACE
-kas.authorizer.acl.logging.005=cluster=*;apis=ALTER_ISR;level=DEBUG
+kas.authorizer.acl.logging.004=cluster=*;apis=ALTER_PARTITION;level=TRACE
+kas.authorizer.acl.logging.005=cluster=*;apis=ALTER_PARTITION;level=DEBUG
 
 # Can still raise log level
 kas.authorizer.acl.logging.006=topic=important_topic;level=WARN


### PR DESCRIPTION
[KAFKA-13587](https://issues.apache.org/jira/browse/KAFKA-13587) renames `ALTER_ISR` to `ALTER_PARTITION`