### PR TITLE
release 2.7.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: kas-broker-plugins
 release:
-  current-version: 2.6.0
-  next-version: 2.6.1-SNAPSHOT
+  current-version: 2.7.0
+  next-version: 2.7.1-SNAPSHOT


### PR DESCRIPTION
release v2.7.0

From the release doc in [readme](https://github.com/bf2fc6cc711aee1a0c2a/kas-broker-plugins#releasing), it looks like for patch release (ex: 2.6.1), we should release in a branch release. But @MikeEdgar said this PR can not be from a fork. So I created this PR to release v2.7.0 against main branch (not sure if we can release v2.6.1 in main branch? I checked the git history, it seems only release major release in main branch).

PS. After all these questions are answered, I'll update the release doc in README to make it clear.