### PR TITLE
Allow immutable configurations if the value matches the default

### DIFF
--- a/src/main/java/io/bf2/kafka/common/rule/ImmutableRule.java
+++ b/src/main/java/io/bf2/kafka/common/rule/ImmutableRule.java
@@ -1,21 +1,37 @@
 package io.bf2.kafka.common.rule;
 
+import scala.collection.immutable.Set$;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * This is a rule that doesn't allow the config value to be updated
  */
 public class ImmutableRule implements ConfigRule {
     private final Set<String> mutableConfigs;
+    private final Map<String, String> defaults;
 
     public ImmutableRule(Set<String> mutableConfigs) {
         this.mutableConfigs = mutableConfigs;
+
+        this.defaults = new kafka.log.LogConfig(Collections.emptyMap(), Set$.MODULE$.empty())
+            .values()
+            .entrySet()
+            .stream()
+            .map(e -> Map.entry(e.getKey(), e.getValue().toString()))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     @Override
     public Optional<String> validate(String key, String val) {
-        if (!mutableConfigs.contains(key)) {
+        String defaultVal = defaults.get(key);
+
+        if (!mutableConfigs.contains(key) && !Objects.equals(defaultVal, val)) {
             return Optional.of(String.format(
                     "Topic configured with invalid configs: %s=%s. This config cannot be updated.", key, val));
         }

--- a/src/test/java/io/bf2/kafka/config/ManagedKafkaAlterConfigPolicyTest.java
+++ b/src/test/java/io/bf2/kafka/config/ManagedKafkaAlterConfigPolicyTest.java
@@ -80,12 +80,15 @@ class ManagedKafkaAlterConfigPolicyTest {
     @ParameterizedTest
     @CsvSource({
             // the following config cannot be updated
-            "retention.ms, true",
-            "message.format.version, false"
+            "retention.ms, Anything, true",
+            "message.format.version, Anything, false",
+            "local.retention.bytes, -2, true",
+            "segment.jitter.ms, 0, true",
+            "segment.jitter.ms, 1, false",
     })
-    void testImmutableRules(String configKey, boolean isValid) {
+    void testImmutableRules(String configKey, String configValue, boolean isValid) {
         RequestMetadata r = buildRequest();
-        Mockito.when(r.configs()).thenReturn(Map.of(configKey, "Doesn't matter"));
+        Mockito.when(r.configs()).thenReturn(Map.of(configKey, configValue));
         if (isValid) {
             assertDoesNotThrow(() -> policy.validate(r));
         } else {


### PR DESCRIPTION
This is just a concept for discussion around how to handle immutable topic properties. It may be a better client experience to allow those configurations that are not explicitly mutable to be set, provided they are the default values that will be used anyway. Additionally, it would remove the need to configure the constant values for enforced configs in kas-fleetshard operator.

I have no doubt that this exact implementation is breaking some Kafka best practice by using the `LogConfig` type :)

Curious to get your thoughts whether this is worthwhile @showuon and @k-wall .