### PR TITLE
Mgdstrm 9801 owner authorizer enhancement

### DIFF
--- a/src/main/java/io/bf2/kafka/authorizer/ApiAwareAccessControlEntry.java
+++ b/src/main/java/io/bf2/kafka/authorizer/ApiAwareAccessControlEntry.java
@@ -58,7 +58,11 @@ class ApiAwareAccessControlEntry extends AccessControlEntry {
 
     @Override
     public AclOperation operation() {
-        throw new UnsupportedOperationException("operation");
+        if(!operationsExcluded && operations.size() == 1){
+            return operations.iterator().next();
+        } else {
+            return AclOperation.UNKNOWN;
+        }
     }
 
     public Set<AclOperation> operations() {

--- a/src/main/java/io/bf2/kafka/authorizer/CustomAclBinding.java
+++ b/src/main/java/io/bf2/kafka/authorizer/CustomAclBinding.java
@@ -179,6 +179,7 @@ class CustomAclBinding extends AclBinding {
         return USER_TYPE_PREFIX + principal;
     }
 
+
     static Set<AclOperation> parseOperations(String value, AclOperation... disallowedValues) {
         return splitOnComma(value).stream()
             .map(AclOperation::fromString)

--- a/src/test/java/io/bf2/kafka/authorizer/CustomAclAuthorizerTest.java
+++ b/src/test/java/io/bf2/kafka/authorizer/CustomAclAuthorizerTest.java
@@ -206,7 +206,8 @@ class CustomAclAuthorizerTest {
     @ParameterizedTest
     @CsvSource({
         "Denied for principal missing 'User:' prefix, user2,ACL rules including principal 'user2' are prohibited - principal is not type User",
-        "Denied for principal in static configuration, User:anonymous, ACL rules including principal 'User:anonymous' are prohibited - this principal is restricted"
+        "Denied for principal in static configuration, User:anonymous, ACL rules including principal 'User:anonymous' are prohibited - this principal is restricted",
+        "Denied for owner principal, User:alice, ACL rules including principal 'User:alice' are prohibited - this principal is an owner"
     })
     void testCreateAclsDeniedForInvalidPrincipal(String title, String principal, String error) throws IOException {
         AclBinding binding1 = new AclBinding(

--- a/src/test/resources/io/bf2/kafka/authorizer/CustomAclAuthorizerTest.properties
+++ b/src/test/resources/io/bf2/kafka/authorizer/CustomAclAuthorizerTest.properties
@@ -24,6 +24,7 @@ kas.authorizer.acl.11=permission=allow;topic=baa;operations=describe;apis-except
 kas.authorizer.acl.12=permission=deny;group=xyz;principal=User:any;operations=read
 # Takes priority over ACL #6
 kas.authorizer.acl.13=permission=allow;listeners=external.*;cluster=*;operations=all;principal=alice;priority=1
+kas.authorizer.owners=alice
 
 # Logging configs
 kas.authorizer.acl.logging.001=cluster=*;apis=fetch;level=TRACE


### PR DESCRIPTION
To improve users ACL management experience we want to:

1. make the static ACL rules for the owners of the kafka cluster visible through the kafka APIs (when describing ACLs)
2. improve the error message when a user with ACL management permissions attempts to create and ACL rule targeting an owner principal

To achieve this we will make the plugin aware of owners by adding a `kas.authorizer.owners` property, where the value is a comma-separated list of owner names. Then we can filter the static rules in memory to rules that explicitly target an owner principal and concatenate them with the ACL rules retrieved from Zookeeper.

Note: `kafka.server.AclApis#handleDescribeAcls` depended on calling `org.apache.kafka.common.requests.DescribeAclsResponse#aclsResources` to convert the AclBindings to a DescribeAclsResponse. This was initially failing for our CustomAclBinding because `ApiAwareAccessControlEntry` did not support `org.apache.kafka.common.acl.AccessControlEntry#operation`, which is used during the translation. So this currently has a hacky implementation which returns the only included operation in the set if it is size 1, else UNKNOWN.